### PR TITLE
Issue #196: Updated to version 1.0.1 worker and obconnsrv dependency

### DIFF
--- a/compose/com.etendoerp.etendorx_connector.yml
+++ b/compose/com.etendoerp.etendorx_connector.yml
@@ -5,7 +5,7 @@ services:
       - "8101:8101"
       - "5025:8000"
     environment:
-      - DEPENDENCIES=com.etendorx.integration:obconn-srv:1.0.0
+      - DEPENDENCIES=com.etendorx.integration:obconn-srv:1.0.1
       - REPO_URL=${ETENDORX_REPOSITORY_URL}
       - REPO_USER=${ETENDORX_REPOSITORY_USER}
       - REPO_PASSWORD=${ETENDORX_REPOSITORY_PASSWORD}
@@ -16,12 +16,13 @@ services:
     volumes:
       - obconnsrv:/root/.gradle
 
-  obconnwrk:
+  worker:
     image: etendo/dynamic-gradle:1.0.0
     ports:
       - "5026:8000"
+      - "8102:8102"
     environment:
-      - DEPENDENCIES=com.etendorx.integration:obconn-wrk:1.0.0
+      - DEPENDENCIES=com.etendorx.integration:obconn-wrk:1.0.1
       - REPO_URL=${ETENDORX_REPOSITORY_URL}
       - REPO_USER=${ETENDORX_REPOSITORY_USER}
       - REPO_PASSWORD=${ETENDORX_REPOSITORY_PASSWORD}
@@ -30,8 +31,8 @@ services:
     networks:
       - etendo
     volumes:
-      - obconnwrk:/root/.gradle
+      - worker:/root/.gradle
 
 volumes:
     obconnsrv:
-    obconnwrk:
+    worker:

--- a/rxconfig/worker.yaml.template
+++ b/rxconfig/worker.yaml.template
@@ -1,5 +1,5 @@
 server:
-  port: 0
+  port: 8102
 
 bootstrap_server: kafka:9092
 async-api-url: http://asyncprocess:8099


### PR DESCRIPTION
This pull request updates the EtendoRx connector configuration to improve versioning and naming consistency, as well as to align with new port assignments. The key changes include updating dependency versions, renaming a service for clarity, and adjusting port configurations.

### Dependency Updates:
* Updated the `DEPENDENCIES` environment variable for both `obconn-srv` and `obconn-wrk` services to use version `1.0.1` instead of `1.0.0` in `compose/com.etendoerp.etendorx_connector.yml`. [[1]](diffhunk://#diff-c6e5971806767e42123ce5afa86372c791a30fe85955430afdbb29cdb7901f05L8-R8) [[2]](diffhunk://#diff-c6e5971806767e42123ce5afa86372c791a30fe85955430afdbb29cdb7901f05L19-R25)

### Service Renaming:
* Renamed the `obconnwrk` service to `worker` for improved clarity and consistency in `compose/com.etendoerp.etendorx_connector.yml`.

### Port and Volume Adjustments:
* Added a new port mapping (`8102:8102`) for the `worker` service in `compose/com.etendoerp.etendorx_connector.yml`.
* Updated the volume name associated with the renamed `worker` service, replacing `obconnwrk` with `worker` in `compose/com.etendoerp.etendorx_connector.yml`.
* Changed the `server.port` configuration for the `worker` service from `0` to `8102` in `rxconfig/worker.yaml.template`.ETP-1221: Updated service version and also renamed from obconnwrk to worker docker container to allow restart this service using this network name