### PR TITLE
Feature ETP-1771: Updated services, refactor and added opentelemetry.

### DIFF
--- a/compose/com.etendoerp.etendorx.yml
+++ b/compose/com.etendoerp.etendorx.yml
@@ -1,12 +1,10 @@
 services:
   config:
     env_file: ".env"
-    image: etendo/dynamic-gradle:1.0.0
+    image: etendo/dynamic-gradle:1.1.0
     ports:
       - "8888:8888"
       - "5020:8000"
-    volumes:
-      - ${VOLUMES_PATH}/rxconfig:/rxconfig
     environment:
       - SPRING_CLOUD_CONFIG_SERVER_NATIVE_SEARCHLOCATIONS=file:///rxconfig
       - SPRING_PROFILES_ACTIVE=native
@@ -16,8 +14,19 @@ services:
       - REPO_PASSWORD=${ETENDORX_REPOSITORY_PASSWORD}
       - CONFIG_SERVER_URL=
       - TASK=downloadJar
+      - ENABLE_OPEN_TELEMETRY=true
+      # --- OpenTelemetry ---
+      - OTEL_SERVICE_NAME=config
+      - OTEL_METRICS_EXPORTER=none
+      - OTEL_LOGS_EXPORTER=none
+      - OTEL_TRACES_EXPORTER=otlp
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318
+      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+      - OTEL_EXPORTER_OTLP_TIMEOUT=10000
     networks:
       - etendo
+    volumes:
+      - ${VOLUMES_PATH}/rxconfig:/rxconfig
     healthcheck:
       test: ["CMD-SHELL", "wget --spider -q http://localhost:8888/actuator/health || exit 1"]
       interval: 10s
@@ -29,7 +38,7 @@ services:
     depends_on:
       config:
         condition: service_healthy
-    image: etendo/dynamic-das:1.0.1
+    image: etendo/dynamic-das:1.1.0
     ports:
       - "8092:8092"
       - "5021:5021"
@@ -44,6 +53,15 @@ services:
       - DB_HOST=${ETENDORX_DB_HOST}
       - DB_PORT=${ETENDORX_DB_PORT}
       - DB_SID=${ETENDORX_DB_SID}
+      # --- OpenTelemetry ---
+      - ENABLE_OPEN_TELEMETRY=true
+      - OTEL_SERVICE_NAME=das
+      - OTEL_METRICS_EXPORTER=none
+      - OTEL_LOGS_EXPORTER=none
+      - OTEL_TRACES_EXPORTER=otlp
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318
+      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+      - OTEL_EXPORTER_OTLP_TIMEOUT=10000
     networks:
       - etendo
     volumes:
@@ -60,7 +78,7 @@ services:
     depends_on:
       config:
         condition: service_healthy
-    image: etendo/dynamic-gradle:1.0.0
+    image: etendo/dynamic-gradle:1.1.0
     ports:
       - "8094:8094"
       - "5022:8000"
@@ -71,6 +89,15 @@ services:
       - REPO_PASSWORD=${ETENDORX_REPOSITORY_PASSWORD}
       - CONFIG_SERVER_URL=${ETENDORX_CONFIG_SERVER_URL}
       - TASK=downloadJar
+      # --- OpenTelemetry ---
+      - ENABLE_OPEN_TELEMETRY=true
+      - OTEL_SERVICE_NAME=auth
+      - OTEL_METRICS_EXPORTER=none
+      - OTEL_LOGS_EXPORTER=none
+      - OTEL_TRACES_EXPORTER=otlp
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318
+      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+      - OTEL_EXPORTER_OTLP_TIMEOUT=10000
     networks:
       - etendo
     volumes:
@@ -86,7 +113,7 @@ services:
     depends_on:
       config:
         condition: service_healthy
-    image: etendo/dynamic-gradle:1.0.0
+    image: etendo/dynamic-gradle:1.1.0
     ports:
       - "8096:8096"
       - "5023:8000"
@@ -97,6 +124,15 @@ services:
       - REPO_PASSWORD=${ETENDORX_REPOSITORY_PASSWORD}
       - CONFIG_SERVER_URL=${ETENDORX_CONFIG_SERVER_URL}
       - TASK=downloadJar
+      # --- OpenTelemetry ---
+      - ENABLE_OPEN_TELEMETRY=true
+      - OTEL_SERVICE_NAME=edge
+      - OTEL_METRICS_EXPORTER=none
+      - OTEL_LOGS_EXPORTER=none
+      - OTEL_TRACES_EXPORTER=otlp
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318
+      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+      - OTEL_EXPORTER_OTLP_TIMEOUT=10000
     networks:
       - etendo
     volumes:
@@ -109,6 +145,7 @@ services:
 
 networks:
   etendo:
+
 volumes:
   das_cache_vol:
   das_app_vol:

--- a/compose/com.etendoerp.etendorx_async.yml
+++ b/compose/com.etendoerp.etendorx_async.yml
@@ -1,45 +1,37 @@
 services:
-  zookeeper:
-    image: confluentinc/cp-zookeeper:latest
-    ports:
-      - "2181:2181"
-      - "22181:22181"
-    environment:
-      ZOOKEEPER_CLIENT_PORT: '2181'
-      ZOOKEEPER_TICK_TIME: '2000'
-    networks:
-      - etendo
-    deploy:
-      resources:
-        limits:
-          cpus: "0.5"
-          memory: 512M
-
   kafka:
-    image: bitnami/kafka:3.6.2
+    image: bitnami/kafka:4.0.0
     ports:
       - "9092:9092"
+      - "9093:9093"
       - "29092:29092"
       - "9997:9997"
     environment:
-      KAFKA_BROKER_ID: '1'
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_LISTENERS: INTERNAL://:29092,EXTERNAL://:9092
-      KAFKA_ADVERTISED_LISTENERS: INTERNAL://:29092,EXTERNAL://kafka:9092
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: '1'
-      JMX_PORT: 9997
+      KAFKA_CFG_PROCESS_ROLES: "controller,broker"
+      KAFKA_CFG_NODE_ID: "1"
+      KAFKA_CLUSTER_ID: "1fAy-_QvR3yHBXb3_K0-Mg"
+      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: "1@kafka:9093"
+      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: "CONTROLLER"
+      KAFKA_CFG_LISTENERS: CONTROLLER://0.0.0.0:9093,INTERNAL://0.0.0.0:29092,EXTERNAL://0.0.0.0:9092
+      KAFKA_CFG_ADVERTISED_LISTENERS: INTERNAL://:29092,EXTERNAL://kafka:9092
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: "INTERNAL"
+      KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
+      ENV KAFKA_METADATA_LOG_SEGMENT_MS: 15000
+      ENV KAFKA_METADATA_MAX_RETENTION_MS: 60000
+      ENV KAFKA_METADATA_LOG_MAX_RECORD_BYTES_BETWEEN_SNAPSHOTS: 2800
+      # --- JMX opcional ---
+      JMX_PORT: "9997"
       KAFKA_JMX_OPTS: -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.net.preferIPv4Stack=true -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.rmi.port=9997
     networks:
       - etendo
-    depends_on:
-      - zookeeper
     deploy:
       resources:
         limits:
           cpus: "1"
           memory: 1G
+    volumes:
+      - ${VOLUMES_PATH}/kafka_data:/bitnami
 
   connect:
     image: debezium/connect:2.7.1.Final
@@ -61,7 +53,7 @@ services:
     depends_on:
       config:
         condition: service_healthy
-    image: etendo/dynamic-gradle:1.0.0
+    image: etendo/dynamic-gradle:1.1.0
     ports:
       - "8099:8099"
       - "5024:8000"
@@ -72,6 +64,15 @@ services:
       - REPO_PASSWORD=${ETENDORX_REPOSITORY_PASSWORD}
       - CONFIG_SERVER_URL=${ETENDORX_CONFIG_SERVER_URL}
       - TASK=downloadJar
+      # --- OpenTelemetry ---
+      - ENABLE_OPEN_TELEMETRY=true
+      - OTEL_SERVICE_NAME=asyncprocess
+      - OTEL_METRICS_EXPORTER=none
+      - OTEL_LOGS_EXPORTER=none
+      - OTEL_TRACES_EXPORTER=otlp
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318
+      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+      - OTEL_EXPORTER_OTLP_TIMEOUT=10000
     networks:
       - etendo
     volumes:
@@ -81,22 +82,6 @@ services:
       interval: 10s
       timeout: 10s
       retries: 60
-
-  kafka-ui:
-    image: provectuslabs/kafka-ui:latest
-    ports:
-      - 9093:8080
-    environment:
-      KAFKA_CLUSTERS_0_NAME: kafka
-      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:29092
-      KAFKA_CLUSTERS_0_METRICS_PORT: 9997
-    networks:
-      - etendo
-    deploy:
-      resources:
-        limits:
-          cpus: "0.5"
-          memory: 512M
 
 volumes:
   async_vol:

--- a/compose/com.etendoerp.etendorx_connector.yml
+++ b/compose/com.etendoerp.etendorx_connector.yml
@@ -1,6 +1,6 @@
 services:
   obconnsrv:
-    image: etendo/dynamic-gradle:1.0.0
+    image: etendo/dynamic-gradle:1.1.0
     ports:
       - "8101:8101"
       - "5025:8000"
@@ -11,13 +11,27 @@ services:
       - REPO_PASSWORD=${ETENDORX_REPOSITORY_PASSWORD}
       - CONFIG_SERVER_URL=${ETENDORX_CONFIG_SERVER_URL}
       - TASK=downloadJar
+      # --- OpenTelemetry ---
+      - ENABLE_OPEN_TELEMETRY=true
+      - OTEL_SERVICE_NAME=obconnsrv
+      - OTEL_METRICS_EXPORTER=none
+      - OTEL_LOGS_EXPORTER=none
+      - OTEL_TRACES_EXPORTER=otlp
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318
+      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+      - OTEL_EXPORTER_OTLP_TIMEOUT=10000
     networks:
       - etendo
     volumes:
       - obconnsrv:/root/.gradle
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider -q http://localhost:8101/actuator/health || exit 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 60
 
   worker:
-    image: etendo/dynamic-gradle:1.0.0
+    image: etendo/dynamic-gradle:1.1.0
     ports:
       - "5026:8000"
       - "8102:8102"
@@ -28,10 +42,24 @@ services:
       - REPO_PASSWORD=${ETENDORX_REPOSITORY_PASSWORD}
       - CONFIG_SERVER_URL=${ETENDORX_CONFIG_SERVER_URL}
       - TASK=downloadJar
+      # --- OpenTelemetry ---
+      - ENABLE_OPEN_TELEMETRY=true
+      - OTEL_SERVICE_NAME=worker
+      - OTEL_METRICS_EXPORTER=none
+      - OTEL_LOGS_EXPORTER=none
+      - OTEL_TRACES_EXPORTER=otlp
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318
+      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+      - OTEL_EXPORTER_OTLP_TIMEOUT=10000
     networks:
       - etendo
     volumes:
       - worker:/root/.gradle
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider -q http://localhost:8102/actuator/health || exit 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 60
 
 volumes:
     obconnsrv:

--- a/compose/com.etendoerp.etendorx_utils.yml
+++ b/compose/com.etendoerp.etendorx_utils.yml
@@ -1,0 +1,41 @@
+services:
+  kafka-ui:
+    image: redpandadata/console
+    ports:
+      - 9094:8080
+    environment:
+      - KAFKA_BROKERS=kafka:9092
+      - CONNECT_BOOTSTRAP_SERVERS=connect:8083
+    networks:
+      - etendo
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 512M
+    restart: on-failure:5
+    depends_on:
+      - kafka
+      - connect
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.70.0
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+      - "14268:14268"
+      - "14250:14250"
+      - "9411:9411"
+      - "16686:16686"
+    environment:
+      COLLECTOR_ZIPKIN_HTTP_ENABLED: true
+      COLLECTOR_ZIPKIN_HTTP_PORT: 9411
+      JAEGER_COLLECTOR_ZIPKIN_HTTP_PORT: 9411
+      JAEGER_AGENT_HOST: jaeger
+      JAEGER_AGENT_PORT: 5775
+      JAEGER_DISABLED: false
+      COLLECTOR_OTLP_ENABLED: true
+      AEGER_OTLP_HTTP_PORT: 4318
+      METRICS_STORAGE_TYPE: prometheus
+    networks:
+      - etendo


### PR DESCRIPTION
This pull request introduces several updates to the Docker Compose configuration files to enhance observability, update dependencies, and improve service management. The key changes include upgrading images, adding OpenTelemetry support, replacing Zookeeper with a Kafka quorum-based setup, and introducing new utilities like Jaeger and Kafka UI.

### Dependency Updates:
* Updated `etendo/dynamic-gradle` image to version `1.1.0` across all services (`compose/com.etendoerp.etendorx.yml`, `compose/com.etendoerp.etendorx_async.yml`, `compose/com.etendoerp.etendorx_connector.yml`). [[1]](diffhunk://#diff-41a0d96d149a1a2c10935c63761d9877594f16203a57785f1ba34061e11b98d8L4-L9) [[2]](diffhunk://#diff-e0d86d2992766bb016ee9e8d95acfcb99063159f6131f945fbfb928952e66bf3L64-R56) [[3]](diffhunk://#diff-c6e5971806767e42123ce5afa86372c791a30fe85955430afdbb29cdb7901f05L3-R3)
* Updated Kafka image from `bitnami/kafka:3.6.2` to `bitnami/kafka:4.0.0` and removed Zookeeper dependency in favor of a quorum-based Kafka configuration (`compose/com.etendoerp.etendorx_async.yml`).

### Observability Enhancements:
* Added OpenTelemetry support to multiple services with environment variables for tracing and metrics export (`compose/com.etendoerp.etendorx.yml`, `compose/com.etendoerp.etendorx_async.yml`, `compose/com.etendoerp.etendorx_connector.yml`). [[1]](diffhunk://#diff-41a0d96d149a1a2c10935c63761d9877594f16203a57785f1ba34061e11b98d8R17-R29) [[2]](diffhunk://#diff-41a0d96d149a1a2c10935c63761d9877594f16203a57785f1ba34061e11b98d8R56-R64) [[3]](diffhunk://#diff-e0d86d2992766bb016ee9e8d95acfcb99063159f6131f945fbfb928952e66bf3R67-R75) [[4]](diffhunk://#diff-c6e5971806767e42123ce5afa86372c791a30fe85955430afdbb29cdb7901f05R14-R34)
* Introduced Jaeger for distributed tracing and monitoring (`compose/com.etendoerp.etendorx_utils.yml`).

### Service Management Improvements:
* Added health checks to ensure service readiness for `obconnsrv` and `worker` services in `compose/com.etendoerp.etendorx_connector.yml`. [[1]](diffhunk://#diff-c6e5971806767e42123ce5afa86372c791a30fe85955430afdbb29cdb7901f05R14-R34) [[2]](diffhunk://#diff-c6e5971806767e42123ce5afa86372c791a30fe85955430afdbb29cdb7901f05R45-R62)
* Added a Kafka UI tool (`redpandadata/console`) for better Kafka cluster management (`compose/com.etendoerp.etendorx_utils.yml`).

### Cleanup and Simplification:
* Removed Zookeeper and Kafka UI services from `compose/com.etendoerp.etendorx_async.yml` as part of the Kafka configuration upgrade. [[1]](diffhunk://#diff-e0d86d2992766bb016ee9e8d95acfcb99063159f6131f945fbfb928952e66bf3L2-R34) [[2]](diffhunk://#diff-e0d86d2992766bb016ee9e8d95acfcb99063159f6131f945fbfb928952e66bf3L85-L100)

### New Utilities:
* Added Jaeger and Kafka UI services to `compose/com.etendoerp.etendorx_utils.yml` for observability and Kafka management.