### PR TITLE
Issue #42: Remove duplicate port and container_name from Kafka config

### DIFF
--- a/compose/com.etendoerp.etendorx.yml
+++ b/compose/com.etendoerp.etendorx.yml
@@ -38,7 +38,7 @@ services:
     depends_on:
       config:
         condition: service_healthy
-    image: etendo/dynamic-das:1.1.0
+    image: etendo/dynamic-das:1.0.1
     ports:
       - "8092:8092"
       - "5021:5021"

--- a/compose/com.etendoerp.etendorx.yml
+++ b/compose/com.etendoerp.etendorx.yml
@@ -1,7 +1,7 @@
 services:
   config:
     env_file: ".env"
-    image: etendo/dynamic-gradle:1.1.0
+    image: etendo/dynamic-gradle:1.0.1
     ports:
       - "8888:8888"
       - "5020:8000"
@@ -14,15 +14,6 @@ services:
       - REPO_PASSWORD=${ETENDORX_REPOSITORY_PASSWORD}
       - CONFIG_SERVER_URL=
       - TASK=downloadJar
-      - ENABLE_OPEN_TELEMETRY=true
-      # --- OpenTelemetry ---
-      - OTEL_SERVICE_NAME=config
-      - OTEL_METRICS_EXPORTER=none
-      - OTEL_LOGS_EXPORTER=none
-      - OTEL_TRACES_EXPORTER=otlp
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318
-      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
-      - OTEL_EXPORTER_OTLP_TIMEOUT=10000
     networks:
       - etendo
     volumes:
@@ -53,15 +44,6 @@ services:
       - DB_HOST=${ETENDORX_DB_HOST}
       - DB_PORT=${ETENDORX_DB_PORT}
       - DB_SID=${ETENDORX_DB_SID}
-      # --- OpenTelemetry ---
-      - ENABLE_OPEN_TELEMETRY=true
-      - OTEL_SERVICE_NAME=das
-      - OTEL_METRICS_EXPORTER=none
-      - OTEL_LOGS_EXPORTER=none
-      - OTEL_TRACES_EXPORTER=otlp
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318
-      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
-      - OTEL_EXPORTER_OTLP_TIMEOUT=10000
     networks:
       - etendo
     volumes:
@@ -78,7 +60,7 @@ services:
     depends_on:
       config:
         condition: service_healthy
-    image: etendo/dynamic-gradle:1.1.0
+    image: etendo/dynamic-gradle:1.0.1
     ports:
       - "8094:8094"
       - "5022:8000"
@@ -89,15 +71,6 @@ services:
       - REPO_PASSWORD=${ETENDORX_REPOSITORY_PASSWORD}
       - CONFIG_SERVER_URL=${ETENDORX_CONFIG_SERVER_URL}
       - TASK=downloadJar
-      # --- OpenTelemetry ---
-      - ENABLE_OPEN_TELEMETRY=true
-      - OTEL_SERVICE_NAME=auth
-      - OTEL_METRICS_EXPORTER=none
-      - OTEL_LOGS_EXPORTER=none
-      - OTEL_TRACES_EXPORTER=otlp
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318
-      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
-      - OTEL_EXPORTER_OTLP_TIMEOUT=10000
     networks:
       - etendo
     volumes:
@@ -113,7 +86,7 @@ services:
     depends_on:
       config:
         condition: service_healthy
-    image: etendo/dynamic-gradle:1.1.0
+    image: etendo/dynamic-gradle:1.0.1
     ports:
       - "8096:8096"
       - "5023:8000"
@@ -124,15 +97,6 @@ services:
       - REPO_PASSWORD=${ETENDORX_REPOSITORY_PASSWORD}
       - CONFIG_SERVER_URL=${ETENDORX_CONFIG_SERVER_URL}
       - TASK=downloadJar
-      # --- OpenTelemetry ---
-      - ENABLE_OPEN_TELEMETRY=true
-      - OTEL_SERVICE_NAME=edge
-      - OTEL_METRICS_EXPORTER=none
-      - OTEL_LOGS_EXPORTER=none
-      - OTEL_TRACES_EXPORTER=otlp
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318
-      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
-      - OTEL_EXPORTER_OTLP_TIMEOUT=10000
     networks:
       - etendo
     volumes:

--- a/compose/com.etendoerp.etendorx_async.yml
+++ b/compose/com.etendoerp.etendorx_async.yml
@@ -1,13 +1,11 @@
 services:
   kafka:
     image: bitnami/kafka:4.0.0
-    container_name: kafka
     hostname: kafka
     ports:
       - "9092:9092"
       - "9093:9093"
       - "29092:29092"
-      - "9093:9093"
       - "9997:9997"
     environment:
       KAFKA_CFG_PROCESS_ROLES: "controller,broker"
@@ -91,3 +89,4 @@ services:
 
 volumes:
   async_vol:
+

--- a/compose/com.etendoerp.etendorx_async.yml
+++ b/compose/com.etendoerp.etendorx_async.yml
@@ -57,7 +57,7 @@ services:
     depends_on:
       config:
         condition: service_healthy
-    image: etendo/dynamic-gradle:1.1.0
+    image: etendo/dynamic-gradle:1.0.1
     ports:
       - "8099:8099"
       - "5024:8000"
@@ -68,15 +68,6 @@ services:
       - REPO_PASSWORD=${ETENDORX_REPOSITORY_PASSWORD}
       - CONFIG_SERVER_URL=${ETENDORX_CONFIG_SERVER_URL}
       - TASK=downloadJar
-      # --- OpenTelemetry ---
-      - ENABLE_OPEN_TELEMETRY=true
-      - OTEL_SERVICE_NAME=asyncprocess
-      - OTEL_METRICS_EXPORTER=none
-      - OTEL_LOGS_EXPORTER=none
-      - OTEL_TRACES_EXPORTER=otlp
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318
-      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
-      - OTEL_EXPORTER_OTLP_TIMEOUT=10000
     networks:
       - etendo
     volumes:

--- a/compose/com.etendoerp.etendorx_connector.yml
+++ b/compose/com.etendoerp.etendorx_connector.yml
@@ -1,6 +1,6 @@
 services:
   obconnsrv:
-    image: etendo/dynamic-gradle:1.1.0
+    image: etendo/dynamic-gradle:1.0.1
     ports:
       - "8101:8101"
       - "5025:8000"
@@ -11,15 +11,6 @@ services:
       - REPO_PASSWORD=${ETENDORX_REPOSITORY_PASSWORD}
       - CONFIG_SERVER_URL=${ETENDORX_CONFIG_SERVER_URL}
       - TASK=downloadJar
-      # --- OpenTelemetry ---
-      - ENABLE_OPEN_TELEMETRY=true
-      - OTEL_SERVICE_NAME=obconnsrv
-      - OTEL_METRICS_EXPORTER=none
-      - OTEL_LOGS_EXPORTER=none
-      - OTEL_TRACES_EXPORTER=otlp
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318
-      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
-      - OTEL_EXPORTER_OTLP_TIMEOUT=10000
     networks:
       - etendo
     volumes:
@@ -31,7 +22,7 @@ services:
       retries: 60
 
   worker:
-    image: etendo/dynamic-gradle:1.1.0
+    image: etendo/dynamic-gradle:1.0.1
     ports:
       - "5026:8000"
       - "8102:8102"
@@ -42,15 +33,6 @@ services:
       - REPO_PASSWORD=${ETENDORX_REPOSITORY_PASSWORD}
       - CONFIG_SERVER_URL=${ETENDORX_CONFIG_SERVER_URL}
       - TASK=downloadJar
-      # --- OpenTelemetry ---
-      - ENABLE_OPEN_TELEMETRY=true
-      - OTEL_SERVICE_NAME=worker
-      - OTEL_METRICS_EXPORTER=none
-      - OTEL_LOGS_EXPORTER=none
-      - OTEL_TRACES_EXPORTER=otlp
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318
-      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
-      - OTEL_EXPORTER_OTLP_TIMEOUT=10000
     networks:
       - etendo
     volumes:


### PR DESCRIPTION
ETP-1966: Removed redundant 'container_name' and duplicated port 9093 in Kafka service definition