### PR TITLE
Issue #42: Add Gradle task to configure Kafka Connect

### DIFF
--- a/compose/com.etendoerp.etendorx_async.yml
+++ b/compose/com.etendoerp.etendorx_async.yml
@@ -1,7 +1,6 @@
 services:
   kafka:
     image: bitnami/kafka:4.0.0
-    container_name: kafka
     hostname: kafka
     ports:
       - "9092:9092"
@@ -15,9 +14,11 @@ services:
       KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: "1@kafka:9093"
       KAFKA_CFG_CONTROLLER_LISTENER_NAMES: "CONTROLLER"
 
-      KAFKA_CFG_LISTENERS: CONTROLLER://0.0.0.0:9093,INTERNAL://0.0.0.0:29092,EXTERNAL://0.0.0.0:9092
-
-      KAFKA_CFG_ADVERTISED_LISTENERS: INTERNAL://kafka:29092,EXTERNAL://kafka:9092
+      # --- Configuration for Kafka Broker ---
+      KAFKA_CFG_LISTENERS: CONTROLLER://0.0.0.0:9093,INTERNAL://0.0.0.0:9092,EXTERNAL://0.0.0.0:29092
+      KAFKA_CFG_ADVERTISED_LISTENERS: INTERNAL://kafka:9092,EXTERNAL://localhost:29092
+      # For INTERNAL connections (inside the docker network) use the "kafka" hostname and 9092 port
+      # For EXTERNAL connections (outside the docker network) use "localhost" hostname and 29092 port
 
       KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
 
@@ -40,7 +41,7 @@ services:
     ports:
       - "8083:8083"
     environment:
-      BOOTSTRAP_SERVERS: kafka:29092
+      BOOTSTRAP_SERVERS: kafka:9092
       GROUP_ID: '1'
       CONFIG_STORAGE_TOPIC: my_connect_configs
       OFFSET_STORAGE_TOPIC: my_connect_offsets
@@ -81,7 +82,7 @@ services:
     ports:
       - 9094:8080
     environment:
-      - KAFKA_BROKERS=kafka:29092
+      - KAFKA_BROKERS=kafka:9092
       - CONNECT_BOOTSTRAP_SERVERS=connect:8083
     networks:
       - etendo

--- a/tasks.gradle
+++ b/tasks.gradle
@@ -121,6 +121,96 @@ task "rx.das.stop" {
     }
 }
 
+task "kafkaConnectSetup" {
+    def connectorName = "default"
+    def dbUser = project.hasProperty('bbdd.systemUser') ? project.getProperty('bbdd.systemUser') : 'postgres'
+    def dbName = project.hasProperty('bbdd.sid') ? project.getProperty('bbdd.sid') : 'etendo'
+    def dbPass = project.hasProperty('bbdd.systemPassword') ? project.getProperty('bbdd.systemPassword') : 'syspass'
+
+    doLast {
+        if (!project.hasProperty('kafka.connect.tables')) {
+            throw new GradleException("You must specify the 'kafka.connect.tables' property.")
+        }
+        def tableIncludeList = project.getProperty('kafka.connect.tables')
+        def dbHost
+        if (project.hasProperty('kafka.connect.bbdd.host')) {
+            dbHost = project.getProperty('kafka.connect.bbdd.host')
+        } else if (project.hasProperty('docker_com.etendoerp.docker_db') && project.getProperty('docker_com.etendoerp.docker_db').toBoolean()) {
+            dbHost = "db"
+        } else {
+            throw new GradleException("You must specify the 'kafka.connect.bbdd.host' property.")
+        }
+
+        println "📡 Checking Kafka Connect for connector '$connectorName'..."
+
+        def configBody = """
+        {
+            "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+            "topic.prefix": "${connectorName}",
+            "database.user": "${dbUser}",
+            "database.dbname": "${dbName}",
+            "database.hostname": "${dbHost}",
+            "database.password": "${dbPass}",
+            "name": "${connectorName}",
+            "table.include.list": "${tableIncludeList}",
+            "plugin.name": "pgoutput",
+            "key.converter": "org.apache.kafka.connect.json.JsonConverter",
+            "key.converter.schemas.enable": "false",
+            "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+            "value.converter.schemas.enable": "false",
+            "snapshot.mode": "no_data"
+        }
+        """.stripIndent().replaceAll('\n', '').replaceAll(' +', ' ')
+
+        def postBody = """
+        {
+            "name": "${connectorName}",
+            "config": ${configBody}
+        }
+        """
+        def kafkaConnectHost
+        if (project.hasProperty('kafka.connect.host')) {
+            kafkaConnectHost = project.getProperty('kafka.connect.host')
+        }else if (project.hasProperty('docker_com.etendoerp.etendorx_async') && project.getProperty('docker_com.etendoerp.etendorx_async').toBoolean()) {
+            kafkaConnectHost = "localhost"
+        } else {
+            throw new GradleException("You must specify the 'kafka.connect.host' property.")
+        }
+
+        def checkProcess = ['curl', '-s', '-o', '/dev/null', '-w', '%{http_code}', "http://${kafkaConnectHost}:8083/connectors/${connectorName}"].execute()
+        def statusCode = checkProcess.text.trim()
+
+        def method = statusCode == "200" ? "PUT" : "POST"
+        def url = statusCode == "200" ?
+                "http://${kafkaConnectHost}:8083/connectors/${connectorName}/config" :
+                "http://${kafkaConnectHost}:8083/connectors"
+
+        def bodyToSend = (method == "PUT") ? configBody : postBody
+
+        println "→ Connector $connectorName ${statusCode == '200' ? 'exists' : 'does not exist'}, doing $method"
+
+        def command = [
+                'curl', '--silent', '--show-error', '--fail',
+                '--request', method,
+                '--url', url,
+                '--header', 'Content-Type: application/json',
+                '--data', bodyToSend
+        ]
+
+        def process = command.execute()
+        def output = new StringWriter()
+        def error = new StringWriter()
+        process.consumeProcessOutput(output, error)
+        def exitCode = process.waitFor()
+
+        if (exitCode != 0) {
+            throw new GradleException("❌ Kafka Connect setup failed:\nSTDOUT: ${output}\nSTDERR: ${error}")
+        } else {
+            println "✅ Kafka Connect $method completed.\n"
+        }
+    }
+}
+
 afterEvaluate {
     if (isRXDockerized() && tasks.hasProperty("generateEnvFile")) {
         tasks.named("generateEnvFile").configure { task ->


### PR DESCRIPTION
ETP-1966: Adds a new Gradle task 'kafkaConnectSetup' that configures a Debezium PostgreSQL connector for Kafka Connect. The task dynamically reads project properties such as the target tables, database host, user, and password. It determines whether to use PUT or POST depending on the connector’s existence and sends the appropriate configuration. Additionally, the docker-compose file was updated to clarify Kafka’s listener setup and improve internal/external connectivity.