### PR TITLE
Issue #52: Prevent including fields without columns in Headless

### DIFF
--- a/src-test/src/com/etendoerp/etendorx/services/DataSourceServletTest.java
+++ b/src-test/src/com/etendoerp/etendorx/services/DataSourceServletTest.java
@@ -28,8 +28,10 @@ import org.openbravo.model.ad.datamodel.Table;
 import org.openbravo.model.ad.ui.Field;
 import org.openbravo.model.ad.ui.Tab;
 import org.openbravo.model.ad.ui.Window;
+import org.openbravo.service.db.DalConnectionProvider;
 
 import com.etendoerp.etendorx.utils.DataSourceUtils;
+import com.etendoerp.openapi.data.OpenAPIRequest;
 
 /**
  * Unit tests for the DataSourceServlet class.
@@ -195,5 +197,113 @@ public class DataSourceServletTest extends WeldBaseTest {
     assertEquals("123", result.getString("csrfToken"));
     JSONObject data = result.getJSONObject(DataSourceConstants.DATA);
     assertEquals("value1", data.getString("field1"));
+  }
+
+  @Test
+  public void testGetTab_IgnoresFieldsWithNullColumnAndOrdersBySeqNo() throws Throwable {
+    // Prepare mocks for OBDal and criteria
+    var mockOBDal = org.mockito.Mockito.mock(org.openbravo.dal.service.OBDal.class);
+    var mockCriteria = org.mockito.Mockito.mock(org.openbravo.dal.service.OBCriteria.class);
+    var mockRequestEntity = org.mockito.Mockito.mock(OpenAPIRequest.class);
+    var mockOpenAPITab = org.mockito.Mockito.mock(com.etendoerp.etendorx.data.OpenAPITab.class);
+    var mockTabLocal = org.mockito.Mockito.mock(org.openbravo.model.ad.ui.Tab.class);
+
+    // Create Field/Column mocks
+    org.openbravo.model.ad.ui.Field fieldWithCol1 = org.mockito.Mockito.mock(org.openbravo.model.ad.ui.Field.class);
+    org.openbravo.model.ad.datamodel.Column col1 = org.mockito.Mockito.mock(
+        org.openbravo.model.ad.datamodel.Column.class);
+    org.openbravo.model.ad.ui.Field fieldWithNullCol = org.mockito.Mockito.mock(org.openbravo.model.ad.ui.Field.class);
+    org.openbravo.model.ad.ui.Field fieldWithCol2 = org.mockito.Mockito.mock(org.openbravo.model.ad.ui.Field.class);
+    org.openbravo.model.ad.datamodel.Column col2 = org.mockito.Mockito.mock(
+        org.openbravo.model.ad.datamodel.Column.class);
+
+    // Wire columns
+    org.mockito.Mockito.when(fieldWithCol1.getColumn()).thenReturn(col1);
+    org.mockito.Mockito.when(fieldWithNullCol.getColumn()).thenReturn(null);
+    org.mockito.Mockito.when(fieldWithCol2.getColumn()).thenReturn(col2);
+
+    // Prepare OpenAPIRequestField mocks used by getSeqNo
+    com.etendoerp.etendorx.data.OpenAPIRequestField apif1 = org.mockito.Mockito.mock(
+        com.etendoerp.etendorx.data.OpenAPIRequestField.class);
+    com.etendoerp.etendorx.data.OpenAPIRequestField apif2 = org.mockito.Mockito.mock(
+        com.etendoerp.etendorx.data.OpenAPIRequestField.class);
+    // apif1 corresponds to col1 with seqNo 2, apif2 to col2 with seqNo 1 -> expect ordering by seqNo
+    org.mockito.Mockito.when(apif1.getField()).thenReturn(fieldWithCol1);
+    org.mockito.Mockito.when(apif1.getSeqno()).thenReturn(2L);
+    org.mockito.Mockito.when(apif2.getField()).thenReturn(fieldWithCol2);
+    org.mockito.Mockito.when(apif2.getSeqno()).thenReturn(1L);
+
+    // Tab fields include the three fields (one null column)
+    java.util.List<org.openbravo.model.ad.ui.Field> adFields = java.util.List.of(fieldWithCol1, fieldWithNullCol,
+        fieldWithCol2);
+    org.mockito.Mockito.when(mockTabLocal.getADFieldList()).thenReturn(adFields);
+
+    // OpenAPIRequest tab wiring
+    // Ensure the OpenAPIRequest tab returns the local mockTab with our ADFieldList
+    org.mockito.Mockito.when(mockOpenAPITab.getRelatedTabs()).thenReturn(mockTabLocal);
+    org.mockito.Mockito.when(mockRequestEntity.getETRXOpenAPITabList()).thenReturn(java.util.List.of(mockOpenAPITab));
+    org.mockito.Mockito.when(mockOpenAPITab.getEtrxOpenapiFieldList()).thenReturn(java.util.List.of(apif1, apif2));
+
+    // Mock static OBDal.getInstance() to return our mockOBDal and criteria behavior
+    try (var obDalStatic = org.mockito.Mockito.mockStatic(org.openbravo.dal.service.OBDal.class)) {
+      // Mock both no-arg and tenant-keyed getInstance calls used by Openbravo utilities
+      obDalStatic.when(OBDal::getInstance).thenReturn(mockOBDal);
+      obDalStatic.when(
+          () -> org.openbravo.dal.service.OBDal.getInstance(org.mockito.ArgumentMatchers.anyString())).thenReturn(
+          mockOBDal);
+      org.mockito.Mockito.when(mockOBDal.createCriteria(OpenAPIRequest.class)).thenReturn(mockCriteria);
+      org.mockito.Mockito.when(mockCriteria.add(org.mockito.ArgumentMatchers.any())).thenReturn(mockCriteria);
+      org.mockito.Mockito.when(mockCriteria.setMaxResults(1)).thenReturn(mockCriteria);
+      org.mockito.Mockito.when(mockCriteria.uniqueResult()).thenReturn(mockRequestEntity);
+
+      // Mock LoginUtils to avoid DB connections during default login retrieval and session filling
+      try (var loginUtilsStatic = org.mockito.Mockito.mockStatic(org.openbravo.base.secureApp.LoginUtils.class)) {
+        // Create a simple RoleDefaults holder using the inner class from LoginUtils
+        org.openbravo.base.secureApp.LoginUtils.RoleDefaults defaults = new org.openbravo.base.secureApp.LoginUtils.RoleDefaults();
+        defaults.role = "-";
+        defaults.client = "-";
+        defaults.warehouse = "-";
+        loginUtilsStatic.when(
+            () -> org.openbravo.base.secureApp.LoginUtils.getLoginDefaults(org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.any(DalConnectionProvider.class))).thenReturn(
+            defaults);
+        loginUtilsStatic.when(
+            () -> org.openbravo.base.secureApp.LoginUtils.fillSessionArguments(org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyString()
+            )).thenAnswer(inv -> null);
+
+        // Mock DataSourceUtils.getHQLColumnName to return stable names
+        try (var dsUtilsStatic = org.mockito.Mockito.mockStatic(com.etendoerp.etendorx.utils.DataSourceUtils.class)) {
+          dsUtilsStatic.when(() -> com.etendoerp.etendorx.utils.DataSourceUtils.getHQLColumnName(
+              org.mockito.ArgumentMatchers.eq(fieldWithCol1))).thenReturn(new String[]{ "col1" });
+          dsUtilsStatic.when(() -> com.etendoerp.etendorx.utils.DataSourceUtils.getHQLColumnName(
+              org.mockito.ArgumentMatchers.eq(fieldWithCol2))).thenReturn(new String[]{ "col2" });
+          // Also stub extractDataSourceAndID because we are mocking the whole static class
+          dsUtilsStatic.when(() -> com.etendoerp.etendorx.utils.DataSourceUtils.extractDataSourceAndID(org.mockito.ArgumentMatchers.eq(DATASOURCE_USERS))).thenReturn(new String[]{ "datasource", "users" });
+
+          // Invoke private static method getTab via MethodHandles lookup (avoids setAccessible)
+          java.lang.invoke.MethodHandles.Lookup lookup = java.lang.invoke.MethodHandles.privateLookupIn(
+              DataSourceServlet.class, java.lang.invoke.MethodHandles.lookup());
+          java.lang.invoke.MethodHandle mh = lookup.findStatic(DataSourceServlet.class, "getTab",
+              java.lang.invoke.MethodType.methodType(org.openbravo.model.ad.ui.Tab.class, String.class,
+                  javax.servlet.http.HttpServletRequest.class, javax.servlet.http.HttpServletResponse.class,
+                  java.util.List.class));
+          java.util.List<com.etendoerp.etendorx.services.wrapper.RequestField> fieldList = new java.util.ArrayList<>();
+          Object tabResult = mh.invoke(DATASOURCE_USERS, mockRequest, mockResponse, fieldList);
+
+          // Assertions: fieldList should contain only fields with non-null columns (2 entries)
+          org.junit.Assert.assertEquals(2, fieldList.size());
+          // After ordering by seqNo, first should be the one with seqNo = 1 (col2), then seqNo = 2 (col1)
+          org.junit.Assert.assertEquals("col2", fieldList.get(0).getName());
+          org.junit.Assert.assertEquals("col1", fieldList.get(1).getName());
+          // Tab result should be the mockTab
+          org.junit.Assert.assertSame(mockTabLocal, tabResult);
+        }
+      }
+    }
   }
 }

--- a/src/com/etendoerp/etendorx/openapi/DynamicDatasourceEndpoint.java
+++ b/src/com/etendoerp/etendorx/openapi/DynamicDatasourceEndpoint.java
@@ -59,7 +59,7 @@ public class DynamicDatasourceEndpoint implements OpenAPIEndpoint {
 
   private ThreadLocal<String> requestedTag = new ThreadLocal<>();
 
-  private static final List<String> extraFields = List.of("_identifier", "$ref", "active", "creationDate", "createdBy",
+  static final List<String> extraFields = List.of("_identifier", "$ref", "active", "creationDate", "createdBy",
       "createdBy$_identifier", "updated", "updatedBy", "updatedBy$_identifier");
 
   /**
@@ -244,6 +244,9 @@ public class DynamicDatasourceEndpoint implements OpenAPIEndpoint {
 
     for (Field adField : fields) {
       Column column = adField.getColumn();
+      if (column == null) {
+        continue;
+      }
       String fieldConverted = getHQLColumnName(false, column.getTable().getDBTableName(), column.getDBColumnName())[0];
       responseJSON.put(fieldConverted, "");
       if (DataSourceUtils.isReferenceToAnotherTable(column.getReference())) {
@@ -438,7 +441,7 @@ public class DynamicDatasourceEndpoint implements OpenAPIEndpoint {
    * @return true if the field is mandatory, false otherwise.
    */
   private boolean isMandatory(Field adField) {
-    return adField.getColumn().isMandatory();
+    return adField.getColumn() != null && adField.getColumn().isMandatory();
   }
 
 

--- a/src/com/etendoerp/etendorx/services/DataSourceServlet.java
+++ b/src/com/etendoerp/etendorx/services/DataSourceServlet.java
@@ -19,7 +19,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import com.etendoerp.etendorx.utils.SelectorHandlerUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.entity.ContentType;
 import org.apache.logging.log4j.LogManager;
@@ -53,6 +52,7 @@ import com.etendoerp.etendorx.services.wrapper.EtendoRequestWrapper;
 import com.etendoerp.etendorx.services.wrapper.EtendoResponseWrapper;
 import com.etendoerp.etendorx.services.wrapper.RequestField;
 import com.etendoerp.etendorx.utils.DataSourceUtils;
+import com.etendoerp.etendorx.utils.SelectorHandlerUtil;
 import com.etendoerp.openapi.data.OpenAPIRequest;
 import com.smf.securewebservices.rsql.OBRestUtils;
 import com.smf.securewebservices.utils.SecureWebServicesUtils;
@@ -356,6 +356,7 @@ public class DataSourceServlet implements WebService {
 
   /**
    * Processes the POST request.
+   *
    * @param request
    * @param response
    * @param tab
@@ -394,8 +395,8 @@ public class DataSourceServlet implements WebService {
 
   /**
    * Prepares the payloads for the POST request.
+   *
    * @param jsonBody
-   * @return
    * @throws JSONException
    */
   private JSONArray preparePayloads(String jsonBody) throws JSONException {
@@ -411,6 +412,7 @@ public class DataSourceServlet implements WebService {
 
   /**
    * Processes the payload for the POST request.
+   *
    * @param request
    * @param response
    * @param tab
@@ -420,7 +422,6 @@ public class DataSourceServlet implements WebService {
    * @param payload
    * @param jsonData
    * @param status
-   * @return
    * @throws Exception
    * @throws OpenAPINotFoundThrowable
    */
@@ -456,6 +457,7 @@ public class DataSourceServlet implements WebService {
 
   /**
    * Sends the response back to the client.
+   *
    * @param response
    * @param jsonResponse
    * @param status
@@ -474,6 +476,7 @@ public class DataSourceServlet implements WebService {
 
   /**
    * Processes the PUT request.
+   *
    * @param request
    * @param response
    * @param fieldList
@@ -553,9 +556,13 @@ public class DataSourceServlet implements WebService {
       }
       tab = req.getETRXOpenAPITabList().get(0).getRelatedTabs();
       for (Field field : tab.getADFieldList()) {
+        Column column = field.getColumn();
+        if (column == null) {
+          continue;
+        }
         String name = DataSourceUtils.getHQLColumnName(field)[0];
         fieldList.add(
-            new RequestField(name, field.getColumn(), getSeqNo(req.getETRXOpenAPITabList().get(0), field.getColumn())));
+            new RequestField(name, column, getSeqNo(req.getETRXOpenAPITabList().get(0), column)));
       }
       fieldList.sort(Comparator.comparing(RequestField::getSeqNo));
     } finally {
@@ -569,10 +576,12 @@ public class DataSourceServlet implements WebService {
    * in the given OpenAPITab. If the field column is not found or the sequence number
    * is null, it returns {@link Long#MAX_VALUE}.
    *
-   * @param openAPITab  The OpenAPITab object containing the list of OpenAPIRequestField objects.
-   * @param fieldColumn The Column object representing the field column to search for.
+   * @param openAPITab
+   *     The OpenAPITab object containing the list of OpenAPIRequestField objects.
+   * @param fieldColumn
+   *     The Column object representing the field column to search for.
    * @return The sequence number (seqno) of the matching field, or {@link Long#MAX_VALUE}
-   *         if the field is not found or its sequence number is null.
+   *     if the field is not found or its sequence number is null.
    */
   private static Long getSeqNo(OpenAPITab openAPITab, Column fieldColumn) {
     Optional<OpenAPIRequestField> optField = openAPITab.getEtrxOpenapiFieldList().stream().filter(
@@ -654,7 +663,8 @@ public class DataSourceServlet implements WebService {
       var type = columnTypes.get(changedColumnN);
       dataInpFormat.put(changedColumnInp,
           DataSourceUtils.valueConvertToInputFormat(propsToChange.get(changedColumnN), type));
-      SelectorHandlerUtil.handleColumnSelector(request, tab, dataInpFormat, changedColumnN, changedColumnInp, dbname2input);
+      SelectorHandlerUtil.handleColumnSelector(request, tab, dataInpFormat, changedColumnN, changedColumnInp,
+          dbname2input);
 
       // suppose to change in productID
       Map<String, Object> parameters2 = createParameters(request, tab.getId(), parentId, recordId, changedColumnInp,
@@ -783,7 +793,8 @@ public class DataSourceServlet implements WebService {
       String type = columnTypes.get(changedColumnN);
       String valueInpFormat = DataSourceUtils.valueConvertToInputFormat(newData.get(changedColumnN), type);
       dataInpFormat.put(changedColumnInp, valueInpFormat);
-      SelectorHandlerUtil.handleColumnSelector(request, DataSourceUtils.getTabByDataSourceName(extractedParts[0]), dataInpFormat,
+      SelectorHandlerUtil.handleColumnSelector(request, DataSourceUtils.getTabByDataSourceName(extractedParts[0]),
+          dataInpFormat,
           changedColumnN, changedColumnInp, dbname2input);
       // suppose to change in productID
       Map<String, Object> parameters2 = createParameters(request,


### PR DESCRIPTION
ETP-2271
This pull request focuses on improving robustness and correctness when handling fields with null columns in both the OpenAPI dynamic datasource endpoint and the data source servlet. It also adds comprehensive unit tests to verify this behavior. The main changes ensure that fields with null columns are skipped in relevant processing, preventing potential null pointer exceptions and ensuring correct ordering and handling of fields.

**Core robustness and correctness improvements:**

* In `DynamicDatasourceEndpoint`, updated the `getRequestBody` and `isMandatory` methods to skip or safely handle fields with null columns, preventing null pointer exceptions and ensuring only valid fields are processed. [[1]](diffhunk://#diff-34619de3f844e923d283a4e7cdf5acb41e987aaf88c87f266e1273502c21530cR247-R249) [[2]](diffhunk://#diff-34619de3f844e923d283a4e7cdf5acb41e987aaf88c87f266e1273502c21530cL441-R444)
* In `DataSourceServlet`, modified the `getTab` method to skip fields with null columns when building the field list and to ensure correct ordering by sequence number, further preventing errors and ensuring correct data structure.

**Testing enhancements:**

* Added new unit tests in `DynamicDatasourceEndpointTest` and `DataSourceServletTest` to verify that fields with null columns are ignored and that field ordering by sequence number is correct. These tests use extensive mocking to isolate and verify the new logic. [[1]](diffhunk://#diff-d3c8c3753251b0fbe6519faf4c18d66d877eb7f88c931593d6f4eadcd64b925dR279-R323) [[2]](diffhunk://#diff-21ce77f2699e6c80f66ab89c043b07517dba22af0bde69cf5dfb8d0d913b6544R201-R308)

**Code quality and maintainability:**

* Changed the visibility of the `extraFields` list in `DynamicDatasourceEndpoint` from private to package-private to facilitate testing.
* Added or improved JavaDoc comments and formatting for better code readability and maintainability. [[1]](diffhunk://#diff-d822417124c0f3563254b6b2a952c0f20914a98bef23677d814a92d296969169R359) [[2]](diffhunk://#diff-d822417124c0f3563254b6b2a952c0f20914a98bef23677d814a92d296969169R398-L398) [[3]](diffhunk://#diff-d822417124c0f3563254b6b2a952c0f20914a98bef23677d814a92d296969169R415) [[4]](diffhunk://#diff-d822417124c0f3563254b6b2a952c0f20914a98bef23677d814a92d296969169L423) [[5]](diffhunk://#diff-d822417124c0f3563254b6b2a952c0f20914a98bef23677d814a92d296969169R460) [[6]](diffhunk://#diff-d822417124c0f3563254b6b2a952c0f20914a98bef23677d814a92d296969169R479) [[7]](diffhunk://#diff-d822417124c0f3563254b6b2a952c0f20914a98bef23677d814a92d296969169L572-R582)

**Minor refactoring:**

* Adjusted import order and formatting for clarity and consistency in several files. [[1]](diffhunk://#diff-21ce77f2699e6c80f66ab89c043b07517dba22af0bde69cf5dfb8d0d913b6544R31-R34) [[2]](diffhunk://#diff-d822417124c0f3563254b6b2a952c0f20914a98bef23677d814a92d296969169L22) [[3]](diffhunk://#diff-d822417124c0f3563254b6b2a952c0f20914a98bef23677d814a92d296969169R55)
* Reformatted long method calls for readability in `DataSourceServlet`. [[1]](diffhunk://#diff-d822417124c0f3563254b6b2a952c0f20914a98bef23677d814a92d296969169L657-R667) [[2]](diffhunk://#diff-d822417124c0f3563254b6b2a952c0f20914a98bef23677d814a92d296969169L786-R797)
* Suppressed unused warnings for a helper method in tests.

These changes collectively improve the reliability of the codebase when dealing with dynamic data sources and ensure that edge cases involving incomplete field definitions are handled gracefully.