### PR TITLE
Feature ETP-2055: Added default limits for Docker resources

### DIFF
--- a/compose/com.etendoerp.etendorx.yml
+++ b/compose/com.etendoerp.etendorx.yml
@@ -51,8 +51,8 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '1'
-          memory: 256M
+          cpus: "${CONFIG_CPU_LIMIT:-${BASE_CONFIG_CPU_LIMIT:-1}}"
+          memory: "${CONFIG_MEMORY_LIMIT:-${BASE_CONFIG_MEMORY_LIMIT:-256M}}"
 
   das:
     env_file: ".env"
@@ -116,8 +116,8 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '1'
-          memory: 512M
+          cpus: "${DAS_CPU_LIMIT:-${BASE_DAS_CPU_LIMIT:-1}}"
+          memory: "${DAS_MEMORY_LIMIT:-${BASE_DAS_MEMORY_LIMIT:-512M}}"
 
   auth:
     env_file: ".env"
@@ -171,9 +171,8 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '1'
-          memory: 256M
-
+          cpus: "${AUTH_CPU_LIMIT:-${BASE_AUTH_CPU_LIMIT:-1}}"
+          memory: "${AUTH_MEMORY_LIMIT:-${BASE_AUTH_MEMORY_LIMIT:-256M}}"
   edge:
     env_file: ".env"
     depends_on:
@@ -226,8 +225,8 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '1'
-          memory: 256M
+          cpus: "${AUTH_CPU_LIMIT:-${BASE_AUTH_CPU_LIMIT:-1}}"
+          memory: "${AUTH_MEMORY_LIMIT:-${BASE_AUTH_MEMORY_LIMIT:-256M}}"
 
 networks:
   etendo:

--- a/compose/com.etendoerp.etendorx_async.yml
+++ b/compose/com.etendoerp.etendorx_async.yml
@@ -33,8 +33,8 @@ services:
     deploy:
       resources:
         limits:
-          cpus: "1"
-          memory: 1G
+          cpus: "${KAFKA_CPU_LIMIT:-${BASE_KAFKA_CPU_LIMIT:-1}}"
+          memory: "${KAFKA_MEMORY_LIMIT:-${BASE_KAFKA_MEMORY_LIMIT:-1G}}"
     volumes:
       - ${VOLUMES_PATH}/kafka_data:/bitnami
 
@@ -56,8 +56,8 @@ services:
     deploy:
       resources:
         limits:
-          cpus: "1"
-          memory: 1G
+          cpus: "${CONNECT_CPU_LIMIT:-${BASE_CONNECT_CPU_LIMIT:-1}}"
+          memory: "${CONNECT_MEMORY_LIMIT:-${BASE_CONNECT_MEMORY_LIMIT:-1G}}"
 
   asyncprocess:
     env_file: ".env"
@@ -112,7 +112,8 @@ services:
     deploy:
       resources:
         limits:
-          memory: 256M
+          cpus: "${ASYNCPROCESS_CPU_LIMIT:-${BASE_ASYNCPROCESS_CPU_LIMIT:-0.25}}"
+          memory: "${ASYNCPROCESS_MEMORY_LIMIT:-${BASE_ASYNCPROCESS_MEMORY_LIMIT:-256M}}"
 
 volumes:
   async_vol:

--- a/compose/com.etendoerp.etendorx_connector.yml
+++ b/compose/com.etendoerp.etendorx_connector.yml
@@ -37,7 +37,8 @@ services:
     deploy:
       resources:
         limits:
-          memory: 256M
+          cpus: "${OBCONNSRV_CPU_LIMIT:-${BASE_OBCONNSRV_CPU_LIMIT:-1}}"
+          memory: "${OBCONNSRV_MEMORY_LIMIT:-${BASE_OBCONNSRV_MEMORY_LIMIT:-256M}}"
 
   worker:
     image: etendo/dynamic-gradle:1.1.0
@@ -77,7 +78,8 @@ services:
     deploy:
       resources:
         limits:
-          memory: 512M
+          cpus: "${WORKER_CPU_LIMIT:-${BASE_WORKER_CPU_LIMIT:-1}}"
+          memory: "${WORKER_MEMORY_LIMIT:-${BASE_WORKER_MEMORY_LIMIT:-512M}}"
 
 volumes:
     obconnsrv:

--- a/compose/com.etendoerp.etendorx_utils.yml
+++ b/compose/com.etendoerp.etendorx_utils.yml
@@ -11,8 +11,8 @@ services:
     deploy:
       resources:
         limits:
-          cpus: "0.5"
-          memory: 128M
+          cpus: "${KAFKA_UI_CPU_LIMIT:-${BASE_KAFKA_UI_CPU_LIMIT:-0.5}}"
+          memory: "${KAFKA_UI_MEMORY_LIMIT:-${BASE_KAFKA_UI_MEMORY_LIMIT:-128M}}"
     restart: on-failure:5
     depends_on:
       - kafka
@@ -35,8 +35,8 @@ services:
     deploy:
       resources:
         limits:
-          cpus: "0.5"
-          memory: 256M
+          cpus: "${JAEGER_CPU_LIMIT:-${BASE_JAEGER_CPU_LIMIT:-0.5}}"
+          memory: "${JAEGER_MEMORY_LIMIT:-${BASE_JAEGER_MEMORY_LIMIT:-256M}}"
     volumes:
       - ${VOLUMES_PATH}/jaeger/config.yaml:/jaeger/config.yaml
 
@@ -53,3 +53,8 @@ services:
       timeout: 5s
       retries: 5
       start_period: 15s
+    deploy:
+      resources:
+        limits:
+          cpus: "${JAEGER_HEALTH_CPU_LIMIT:-${BASE_JAEGER_HEALTH_CPU_LIMIT:-0.5}}"
+          memory: "${JAEGER_HEALTH_MEMORY_LIMIT:-${BASE_JAEGER_HEALTH_MEMORY_LIMIT:-64M}}"

--- a/tasks.gradle
+++ b/tasks.gradle
@@ -168,6 +168,76 @@ task "rx.env.file" {
         }
         def configServerUrl = "http://${tomcatHost}:${tomcatPort}/${contextName}/buildConfig"
         upsertEnvProperty("ETENDORX_CONFIG_SERVER_URL", configServerUrl)
+
+        // EtendoRX Resource Limits
+        def RX_BASE_MEM_MB = getTypedProp("rx.base.memory.mb") ?: 256
+        def RX_BASE_CPU = getTypedProp("rx.base.cpu") ?: 1.0
+
+        def rxServiceFactors = [
+            CONFIG: [mem: 1.0, cpu: 1.0], // Default 256Mb - 1 Cpu
+            DAS   : [mem: 2.0, cpu: 1.0], // Default 512Mb - 1 Cpu
+            AUTH  : [mem: 1.0, cpu: 1.0], // Default 256Mb - 1 Cpu
+            EDGE  : [mem: 1.0, cpu: 1.0]  // Default 256Mb - 1 Cpu
+        ]
+        rxServiceFactors.each { service, factors ->
+            def memMB = (RX_BASE_MEM_MB * factors.mem).toInteger()
+            def cpu = ((RX_BASE_CPU * factors.cpu) as BigDecimal).setScale(3, BigDecimal.ROUND_HALF_UP).toString()
+
+            upsertEnvProperty("BASE_${service}_MEMORY_LIMIT", "${memMB}M")
+            upsertEnvProperty("BASE_${service}_CPU_LIMIT", "${cpu}")
+        }
+
+        // Connector Resource Limits
+        def CONNECTOR_BASE_MEM_MB = getTypedProp("connector.base.memory.mb") ?: 256
+        def CONNECTOR_BASE_CPU = getTypedProp("connector.base.cpu") ?: 1.0
+
+        def connectorServiceFactors = [
+            OBCONNSRV: [mem: 1.0, cpu: 1.0],  // Default 256Mb - 1 Cpu
+            WORKER   : [mem: 2.0, cpu: 1.0]   // Default 512Mb - 3 Cpu3
+        ]
+        connectorServiceFactors.each { service, factors ->
+            def memMB = (CONNECTOR_BASE_MEM_MB * factors.mem).toInteger()
+            def cpu = ((CONNECTOR_BASE_CPU * factors.cpu) as BigDecimal).setScale(3, BigDecimal.ROUND_HALF_UP).toString()
+
+            upsertEnvProperty("BASE_${service}_MEMORY_LIMIT", "${memMB}M")
+            upsertEnvProperty("BASE_${service}_CPU_LIMIT", "${cpu}")
+        }
+
+        // Async Process Resource Limits
+        def ASYNC_BASE_MEM_MB = getTypedProp("async.base.memory.mb") ?: 256
+        def ASYNC_BASE_CPU    = getTypedProp("async.base.cpu") ?: 1.0
+
+        // Factores por servicio
+        def asyncServiceFactors = [
+            KAFKA        : [mem: 4.0, cpu: 2.0],  // Default 1024Mb - 1 Cpu
+            CONNECT      : [mem: 4.0, cpu: 1.0],  // Default 1024Mb - 1 Cpu
+            ASYNCPROCESS : [mem: 1.0, cpu: 1.0]   // Default 256Mb - 1 Cpu
+        ]
+        asyncServiceFactors.each { service, factors ->
+            def memMB = (ASYNC_BASE_MEM_MB * factors.mem).toInteger()
+            def cpu = ((ASYNC_BASE_CPU * factors.cpu) as BigDecimal).setScale(3, BigDecimal.ROUND_HALF_UP).toString()
+
+            upsertEnvProperty("BASE_${service}_MEMORY_LIMIT", "${memMB}M")
+            upsertEnvProperty("BASE_${service}_CPU_LIMIT", "${cpu}")
+        }
+
+        // Utils Resource Limits
+        // --- Base y factores ---
+        def UTILS_BASE_MEM_MB = getTypedProp("utils.base.memory.mb") ?: 256
+        def UTILS_BASE_CPU    = getTypedProp("utils.base.cpu") ?: 1.0
+
+        def utilsServiceFactors = [
+            KAFKA_UI      : [mem: 0.5,  cpu: 0.5],  // Default 128Mb - 0.5 Cpu
+            JAEGER        : [mem: 1.0,  cpu: 0.5],  // Default 256Mb - 0.5 Cpu
+            JAEGER_HEALTH : [mem: 0.25, cpu: 0.5]   // Default 64Mb - 0.5 Cpu
+        ]
+        utilsServiceFactors.each { service, factors ->
+            def memMB = (UTILS_BASE_MEM_MB * factors.mem).toInteger()
+            def cpu = ((UTILS_BASE_CPU * factors.cpu) as BigDecimal).setScale(3, BigDecimal.ROUND_HALF_UP).toString()
+
+            upsertEnvProperty("BASE_${service}_MEMORY_LIMIT", "${memMB}M")
+            upsertEnvProperty("BASE_${service}_CPU_LIMIT", "${cpu}")
+        }
     }
 }
 


### PR DESCRIPTION
This pull request introduces a standardized and flexible approach for configuring resource limits (CPU and memory) for all services defined in the Docker Compose files. It does this by parameterizing the resource limits using environment variables, which are now generated dynamically in the `tasks.gradle` build script based on configurable base values and service-specific scaling factors. This change makes it easier to adjust resource allocations without modifying the Compose files directly and supports better customization for different deployment environments.

Key changes:

**Resource Limit Parameterization in Compose Files**
- All `cpus` and `memory` resource limits in the various `compose/*.yml` files are now set using environment variables, with sensible defaults and support for overrides via base and service-specific variables. [[1]](diffhunk://#diff-41a0d96d149a1a2c10935c63761d9877594f16203a57785f1ba34061e11b98d8L54-R55) [[2]](diffhunk://#diff-41a0d96d149a1a2c10935c63761d9877594f16203a57785f1ba34061e11b98d8L119-R120) [[3]](diffhunk://#diff-41a0d96d149a1a2c10935c63761d9877594f16203a57785f1ba34061e11b98d8L174-R175) [[4]](diffhunk://#diff-41a0d96d149a1a2c10935c63761d9877594f16203a57785f1ba34061e11b98d8L229-R229) [[5]](diffhunk://#diff-e0d86d2992766bb016ee9e8d95acfcb99063159f6131f945fbfb928952e66bf3L36-R37) [[6]](diffhunk://#diff-e0d86d2992766bb016ee9e8d95acfcb99063159f6131f945fbfb928952e66bf3L59-R60) [[7]](diffhunk://#diff-e0d86d2992766bb016ee9e8d95acfcb99063159f6131f945fbfb928952e66bf3L115-R116) [[8]](diffhunk://#diff-c6e5971806767e42123ce5afa86372c791a30fe85955430afdbb29cdb7901f05L40-R41) [[9]](diffhunk://#diff-c6e5971806767e42123ce5afa86372c791a30fe85955430afdbb29cdb7901f05L80-R82) [[10]](diffhunk://#diff-423726f99d1e14e3decfe3e3dcf879c2f36214c27ffa3adaa760f26e0fadbed0L14-R15) [[11]](diffhunk://#diff-423726f99d1e14e3decfe3e3dcf879c2f36214c27ffa3adaa760f26e0fadbed0L38-R39) [[12]](diffhunk://#diff-423726f99d1e14e3decfe3e3dcf879c2f36214c27ffa3adaa760f26e0fadbed0R56-R60)

**Automated Environment Variable Generation**
- The `tasks.gradle` script now computes and sets the base and per-service resource limit environment variables (`BASE_<SERVICE>_MEMORY_LIMIT`, `BASE_<SERVICE>_CPU_LIMIT`) using configurable base values and service-specific factors for each service group (core, connector, async, utils). This ensures all Compose files can reference these variables for consistent configuration.

**Improved Flexibility and Maintainability**
- By centralizing resource configuration in environment variables and the build script, adjustments for scaling or tuning services can be made in one place, reducing duplication and risk of misconfiguration across multiple Compose files.

Let me know if you have questions about how to adjust the resource allocations or the new environment variable structure!