### PR TITLE
Issue #62: Added tags to Docker images and Gradle task dependency

### DIFF
--- a/compose/com.etendoerp.etendorx.yml
+++ b/compose/com.etendoerp.etendorx.yml
@@ -1,6 +1,7 @@
 services:
   config:
     env_file: ".env"
+    image: ${CONTEXT_NAME:-etendo}/config:${ETENDORX_VERSION:-latest}
     build:
       context: .
       dockerfile: dynamic/Dockerfile
@@ -58,6 +59,7 @@ services:
     depends_on:
       config:
         condition: service_healthy
+    image: ${CONTEXT_NAME:-etendo}/das:${ETENDORX_VERSION:-latest}
     build:
       context: .
       dockerfile: das/Dockerfile
@@ -120,6 +122,7 @@ services:
     depends_on:
       config:
         condition: service_healthy
+    image: ${CONTEXT_NAME:-etendo}/auth:${ETENDORX_VERSION:-latest}
     build:
       context: .
       dockerfile: dynamic/Dockerfile
@@ -172,6 +175,7 @@ services:
     depends_on:
       config:
         condition: service_healthy
+    image: ${CONTEXT_NAME:-etendo}/edge:${ETENDORX_VERSION:-latest}
     build:
       context: .
       dockerfile: dynamic/Dockerfile

--- a/compose/das/Dockerfile
+++ b/compose/das/Dockerfile
@@ -89,7 +89,7 @@ RUN wget https://github.com/open-telemetry/opentelemetry-java-instrumentation/re
 # STAGE 4: RUNTIME
 # Final lightweight image, using the customized JRE from the 'jlinker' stage.
 # =========================================================================================
-FROM alpine:3.20
+FROM alpine:3.20 AS dynamic-das
 
 # Runtime arguments
 ARG DEBUG_PORT=5021

--- a/compose/dynamic/Dockerfile
+++ b/compose/dynamic/Dockerfile
@@ -40,7 +40,7 @@ RUN wget https://github.com/open-telemetry/opentelemetry-java-instrumentation/re
 
 # Stage 3: Runtime - The final, lightweight and optimized image
 # This is the final image that will run. It is based on Alpine Linux, which is very lightweight.
-FROM alpine:3.20
+FROM alpine:3.20 AS dynamic-gradle
 ARG DEBUG_PORT=8000
 ARG SPRING_PROFILES_ACTIVE
 ARG SPRING_CLOUD_CONFIG_SERVER_NATIVE_SEARCHLOCATIONS

--- a/tasks.gradle
+++ b/tasks.gradle
@@ -482,4 +482,9 @@ afterEvaluate {
             }
         }
     }
+    if (isRXDockerized() && tasks.named("install")) {
+        tasks.named("install").configure { task ->
+            task.finalizedBy("resources.build")
+        }
+    }
 }


### PR DESCRIPTION

This pull request updates the Docker Compose setup and Dockerfiles to improve image management and build clarity for multiple services, and adds a Gradle task dependency when running in a Dockerized environment. The most important changes are:

**Docker Compose image specification improvements:**

* Explicitly sets the `image` field for the `config`, `das`, `auth`, and `edge` services in `compose/com.etendoerp.etendorx.yml`, allowing for more predictable image naming and versioning using environment variables. [[1]](diffhunk://#diff-41a0d96d149a1a2c10935c63761d9877594f16203a57785f1ba34061e11b98d8R4) [[2]](diffhunk://#diff-41a0d96d149a1a2c10935c63761d9877594f16203a57785f1ba34061e11b98d8R62) [[3]](diffhunk://#diff-41a0d96d149a1a2c10935c63761d9877594f16203a57785f1ba34061e11b98d8R125) [[4]](diffhunk://#diff-41a0d96d149a1a2c10935c63761d9877594f16203a57785f1ba34061e11b98d8R178)

**Dockerfile build stage naming:**

* Adds explicit build stage names (`AS dynamic-das` and `AS dynamic-gradle`) to the final `alpine:3.20` images in `compose/das/Dockerfile` and `compose/dynamic/Dockerfile`, improving clarity for multi-stage builds. [[1]](diffhunk://#diff-91967ce4ac036d082a5e98408fb9eef831b388be8b2489cd4628f067bd285568L92-R92) [[2]](diffhunk://#diff-d9e79f0b9302e8f88e2f1187313cf386c6d34f0025eb0b3410e97659b9ff8634L43-R43)

**Gradle build process enhancement:**

* Ensures that in a Dockerized environment, the `install` Gradle task is always followed by the `resources.build` task by adding a finalizedBy dependency in `tasks.gradle`.