### PR TITLE
Issue #66: Changed Kafka image.

### DIFF
--- a/compose/com.etendoerp.etendorx_async.yml
+++ b/compose/com.etendoerp.etendorx_async.yml
@@ -1,6 +1,6 @@
 services:
   kafka:
-    image: bitnami/kafka:4.0.0
+    image: public.ecr.aws/bitnami/kafka:4.0.0
     hostname: kafka
     ports:
       - "9092:9092"
@@ -72,7 +72,7 @@ services:
     volumes:
       - async_vol:/root/.gradle
     healthcheck:
-      test: ["CMD-SHELL", "wget --spider -q http://localhost:8099/actuator/health || exit 1"]
+      test: [ "CMD-SHELL", "wget --spider -q http://localhost:8099/actuator/health || exit 1" ]
       interval: 10s
       timeout: 10s
       retries: 60


### PR DESCRIPTION
ETP-2481

This PR updates the Kafka Docker image source to use AWS ECR's public registry instead of the default Docker Hub registry, addressing issue https://github.com/etendosoftware/com.etendoerp.etendorx/pull/66.

Changed Kafka image from bitnami/kafka:4.0.0 to public.ecr.aws/bitnami/kafka:4.0.0
Link to the notice: https://hub.docker.com/r/bitnami/kafka